### PR TITLE
utf8 flag bit

### DIFF
--- a/headers/entryHeader.js
+++ b/headers/entryHeader.js
@@ -93,6 +93,16 @@ module.exports = function () {
         set offset (val) { _offset = val },
 
         get encripted () { return (_flags & 1) === 1 },
+        
+        get isUTF8() { return (this.flags & 0x800) !== 0 },
+        set isUTF8(/** Boolean */ val) {
+            // Bit 11 == 0x800
+            if (val){
+                this.flags |= 0x800;
+            }else{
+                this.flags &= 0xf7ff;   // Just clear one bit
+            }
+        },
 
         get entryHeaderSize () {
             return Constants.CENHDR + _fnameLen + _extraLen + _comLen;

--- a/test/mocha.js
+++ b/test/mocha.js
@@ -3,82 +3,106 @@ const Attr = require("../util").FileAttr;
 const Zip = require("../adm-zip");
 const pth = require("path");
 const fs = require("fs");
+const crypto =  require('crypto');
 const rimraf = require("rimraf")
 
 describe('adm-zip', () => {
+    describe('file extraction tests', () => {
+        const destination = './test/xxx'
 
-    const destination = './test/xxx'
+        beforeEach(done => {
+            rimraf(destination, err => {
+                if (err) return done(err)
+                console.log('Cleared directory: ' + destination)
+                return done()
+            })
+        })
 
-    beforeEach(done => {
-        rimraf(destination, err => {
-            if (err) return done(err)
-            console.log('Cleared directory: ' + destination)
-            return done()
+        it('zip.extractAllTo()', () => {
+            const zip = new Zip('./test/assets/ultra.zip');
+            zip.extractAllTo(destination);
+            const files = walk(destination)
+
+            expect(files.sort()).to.deep.equal([
+                "./test/xxx/attributes_test/asd/New Text Document.txt",
+                "./test/xxx/attributes_test/blank file.txt",
+                "./test/xxx/attributes_test/New folder/hidden.txt",
+                "./test/xxx/attributes_test/New folder/hidden_readonly.txt",
+                "./test/xxx/attributes_test/New folder/readonly.txt",
+                "./test/xxx/utes_test/New folder/somefile.txt"
+            ].sort());
+        })
+
+        it('zip.extractEntryTo(entry, destination, false, true)', () => {
+            const destination = './test/xxx'
+            const zip = new Zip('./test/assets/ultra.zip');
+            var zipEntries = zip.getEntries();
+            zipEntries.forEach(e => zip.extractEntryTo(e, destination, false, true));
+
+            const files = walk(destination)
+            expect(files.sort()).to.deep.equal([
+                "./test/xxx/blank file.txt",
+                "./test/xxx/hidden.txt",
+                "./test/xxx/hidden_readonly.txt",
+                "./test/xxx/New Text Document.txt",
+                "./test/xxx/readonly.txt",
+                "./test/xxx/somefile.txt"
+            ].sort());
+        })
+
+        it('zip.extractEntryTo(entry, destination, true, true)', () => {
+            const destination = './test/xxx'
+            const zip = new Zip('./test/assets/ultra.zip');
+            var zipEntries = zip.getEntries();
+            zipEntries.forEach(e => zip.extractEntryTo(e, destination, true, true));
+
+            const files = walk(destination)
+            expect(files.sort()).to.deep.equal([
+                "./test/xxx/attributes_test/asd/New Text Document.txt",
+                "./test/xxx/attributes_test/blank file.txt",
+                "./test/xxx/attributes_test/New folder/hidden.txt",
+                "./test/xxx/attributes_test/New folder/hidden_readonly.txt",
+                "./test/xxx/attributes_test/New folder/readonly.txt",
+                "./test/xxx/utes_test/New folder/somefile.txt"
+            ].sort());
+        })
+
+        it('passes issue-237-Twizzeld test case', () => {
+            const zip = new Zip('./test/assets/issue-237-Twizzeld.zip');
+            const zipEntries = zip.getEntries();
+            zipEntries.forEach(function (zipEntry) {
+                if (!zipEntry.isDirectory) {
+                    zip.extractEntryTo(zipEntry, './', false, true);
+                    // This should create text.txt on the desktop.
+                    // It will actually create two, but the first is overwritten by the second.
+                }
+            });
+            let text = fs.readFileSync('./text.txt').toString()
+            expect(text).to.equal('ride em cowboy!')
+            fs.unlinkSync('./text.txt')
         })
     })
 
-    it('zip.extractAllTo()', () => {
-        const zip = new Zip('./test/assets/ultra.zip');
-        zip.extractAllTo(destination);
-        const files = walk(destination)
+    describe('file creation test', () => {
+        describe('create file with unicode filename', () => {
+            const file1 = {name:'Snøfall.txt', content: Buffer.from('test')};
+            const zip = new Zip();
+            zip.addFile(file1.name, file1.content);
+            const entry = zip.getEntry(file1.name)
 
-        expect(files.sort()).to.deep.equal([
-            "./test/xxx/attributes_test/asd/New Text Document.txt",
-            "./test/xxx/attributes_test/blank file.txt",
-            "./test/xxx/attributes_test/New folder/hidden.txt",
-            "./test/xxx/attributes_test/New folder/hidden_readonly.txt",
-            "./test/xxx/attributes_test/New folder/readonly.txt",
-            "./test/xxx/utes_test/New folder/somefile.txt"
-        ].sort());
-    })
-
-    it('zip.extractEntryTo(entry, destination, false, true)', () => {
-        const destination = './test/xxx'
-        const zip = new Zip('./test/assets/ultra.zip');
-        var zipEntries = zip.getEntries();
-        zipEntries.forEach(e => zip.extractEntryTo(e, destination, false, true));
-
-        const files = walk(destination)
-        expect(files.sort()).to.deep.equal([
-            "./test/xxx/blank file.txt",
-            "./test/xxx/hidden.txt",
-            "./test/xxx/hidden_readonly.txt",
-            "./test/xxx/New Text Document.txt",
-            "./test/xxx/readonly.txt",
-            "./test/xxx/somefile.txt"
-        ].sort());
-    })
-
-    it('zip.extractEntryTo(entry, destination, true, true)', () => {
-        const destination = './test/xxx'
-        const zip = new Zip('./test/assets/ultra.zip');
-        var zipEntries = zip.getEntries();
-        zipEntries.forEach(e => zip.extractEntryTo(e, destination, true, true));
-
-        const files = walk(destination)
-        expect(files.sort()).to.deep.equal([
-            "./test/xxx/attributes_test/asd/New Text Document.txt",
-            "./test/xxx/attributes_test/blank file.txt",
-            "./test/xxx/attributes_test/New folder/hidden.txt",
-            "./test/xxx/attributes_test/New folder/hidden_readonly.txt",
-            "./test/xxx/attributes_test/New folder/readonly.txt",
-            "./test/xxx/utes_test/New folder/somefile.txt"
-        ].sort());
-    })
-
-    it('passes issue-237-Twizzeld test case', () => {
-        const zip = new Zip('./test/assets/issue-237-Twizzeld.zip');
-        const zipEntries = zip.getEntries();
-        zipEntries.forEach(function (zipEntry) {
-            if (!zipEntry.isDirectory) {
-                zip.extractEntryTo(zipEntry, './', false, true);
-                // This should create text.txt on the desktop.
-                // It will actually create two, but the first is overwritten by the second.
-            }
-        });
-        let text = fs.readFileSync('./text.txt').toString()
-        expect(text).to.equal('ride em cowboy!')
-        fs.unlinkSync('./text.txt')
+            // do we get zipentry with correct filename
+            it('we got zipEntry with given name', () => {
+                expect(entry).to.be.a('object');
+            })
+            // try keep file datetime constant so resulting hash would be same
+            if (entry) entry.header.time = new Date(Date.UTC(1980,0,1,12)); // 1980/01/01 12:00 Z
+            // generate zip buffer and then hash
+            const hash = createHash(zip.toBuffer());
+            // is hash same ??
+            it('returned zipfile has expected hash value', () => {
+                expect(hash).to.equal('4zUoVRlwo1exO1q0ur/9+Q==')
+            })
+        })
     })
 })
 
@@ -112,4 +136,12 @@ function walkD(dir) {
         }
     });
     return results;
+}
+
+function createHash(buffer) {
+    const hash = crypto
+        .createHash('md5')
+        .update(buffer)
+        .digest('base64');
+    return hash;
 }

--- a/zipEntry.js
+++ b/zipEntry.js
@@ -190,11 +190,14 @@ module.exports = function (/*Buffer*/input) {
 
 
     return {
-        get entryName () { return _entryName.toString(); },
+        get entryName () { return _entryName.toString(_entryHeader.isUTF8 ? 'utf8' : 'latin1' ); },
         get rawEntryName() { return _entryName; },
         set entryName (val) {
             _entryName = Utils.toBuffer(val);
-            var lastChar = _entryName[_entryName.length - 1];
+            // utf8 is hardcoded in Utils.toBuffer, but other apps wont understand it without flag bit to be set
+            if (val && typeof val === 'string') _entryHeader.isUTF8 = true;
+            // zero length is allowed, but it will generate error because 0 - 1 = -1
+            var lastChar = _entryName.length > 0 ? _entryName[_entryName.length - 1] : '';
             _isDirectory = (lastChar === 47) || (lastChar === 92);
             _entryHeader.fileNameLength = _entryName.length;
         },


### PR DESCRIPTION
utf8 filenames need bit 11 to be set, so those names are distinguishable from old IBM codepage 437 filenames.